### PR TITLE
Prometheus healthchecks

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,3 +183,17 @@ public class Startup
 | idsrv_unhandled_exceptions_total | Counter  | Gets raised for unhandled exceptions |
 | idsrv_device_authorization_success_total | Counter  | Gets raised for successful device authorization requests |
 | idsrv_device_authorization_success_total | Counter  | Gets raised for failed device authorization requests |
+
+## Prometheus healthchecks
+It is possible to publish all healthchecks results to a prometheus
+```csharp
+public virtual void ConfigureServices(IServiceCollection services)
+{
+    services.AddHealthChecks()
+        .AddSqlServer("<Connection String>", name: "sqlserver")
+
+    services.AddSingleton<IHealthCheckPublisher, PrometheusHealthcheckPublisher>();
+
+    return services;
+}
+```

--- a/samples/WebApp/WebApp.csproj
+++ b/samples/WebApp/WebApp.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="3.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="3.0.1" />
-    <PackageReference Include="prometheus-net" Version="3.3.0" />
-    <PackageReference Include="prometheus-net.AspNetCore" Version="3.3.0" />
+    <PackageReference Include="prometheus-net" Version="3.4.0" />
+    <PackageReference Include="prometheus-net.AspNetCore" Version="3.4.0" />
     <PackageReference Include="StackExchange.Redis" Version="2.0.601" />
   </ItemGroup>
 

--- a/src/prometheus-net.Contrib/Healthchecks/PrometheusHealthcheckPublisher.cs
+++ b/src/prometheus-net.Contrib/Healthchecks/PrometheusHealthcheckPublisher.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Prometheus;
+
+namespace Prometheus.Contrib.Healthchecks
+{        
+    public class PrometheusHealthcheckPublisher : IHealthCheckPublisher
+    {
+        private static readonly Gauge Healthcheck = Metrics.CreateGauge(
+            "health_check",
+            "Prometheus healthcheck.",
+            new GaugeConfiguration { LabelNames = new[] { "serviceName" } });
+
+        public Task PublishAsync(HealthReport report, CancellationToken cancellationToken)
+        {
+            foreach (var entry in report.Entries)
+            {
+                Healthcheck.WithLabels(entry.Key).Set(Convert.ToDouble(entry.Value.Status == HealthStatus.Healthy));
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}


### PR DESCRIPTION
It is possible to publish all healthchecks results to a prometheus
```csharp
public virtual void ConfigureServices(IServiceCollection services)
{
    services.AddHealthChecks()
        .AddSqlServer("<Connection String>", name: "sqlserver")

    services.AddSingleton<IHealthCheckPublisher, PrometheusHealthcheckPublisher>();

    return services;
}
```