### PR TITLE
Increase HttpClient counter when request task is canceled

### DIFF
--- a/src/prometheus-net.Contrib/Diagnostics/HttpClientListenerHandler.cs
+++ b/src/prometheus-net.Contrib/Diagnostics/HttpClientListenerHandler.cs
@@ -22,30 +22,22 @@ namespace Prometheus.Contrib.Diagnostics
                 "Total HTTP requests sent errors.");
         }
 
-        private readonly PropertyFetcher<object> stopResponseFetcher = new PropertyFetcher<object>("Response");
+        private readonly PropertyFetcher<HttpResponseMessage> stopResponseFetcher = new PropertyFetcher<HttpResponseMessage>("Response");
         
-        private readonly PropertyFetcher<object> stopRequestFetcher = new PropertyFetcher<object>("Request");
+        private readonly PropertyFetcher<HttpRequestMessage> stopRequestFetcher = new PropertyFetcher<HttpRequestMessage>("Request");
 
         public HttpClientListenerHandler(string sourceName) : base(sourceName)
         {
         }
 
         public override void OnStopActivity(Activity activity, object payload)
-        {
-            var response = stopResponseFetcher.Fetch(payload);
-
-            if (response is HttpResponseMessage httpResponse)
-            {
+        { 
+            if(stopResponseFetcher.TryFetch(payload, out HttpResponseMessage httpResponse) && httpResponse != null)
                 PrometheusCounters.HttpClientRequestsDuration
                     .WithLabels(httpResponse.StatusCode.ToString("D"), httpResponse.RequestMessage.RequestUri.Host)
                     .Observe(activity.Duration.TotalSeconds);
-                
-                return;
-            }
-
-            var request = stopRequestFetcher.Fetch(payload);
-
-            if (request is HttpRequestMessage httpRequest)
+            
+            else if(stopRequestFetcher.TryFetch(payload, out HttpRequestMessage httpRequest) && httpRequest != null)
                 PrometheusCounters.HttpClientRequestsDuration
                     .WithLabels("0", httpRequest.RequestUri.Host)
                     .Observe(activity.Duration.TotalSeconds);


### PR DESCRIPTION
When a httpclient request is canceled the metric `http_client_requests_duration_seconds` is not increased. I have set the status code to 0 to match `aspnetcore_requests_duration_seconds`.

In the draft PR https://github.com/alexvaluyskiy/prometheus-net-contrib/pull/28 I added a test for this case, but, my changes are more invasive. So I would like to get some feedback from the maintainers on how you plan to test the code before I am changing stuff around.